### PR TITLE
feat: add The Stall MCP — 210 OSINT-relevant pay-per-call capabilities via x402 (v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ A list of articles, videos, and tools related to the use of AI for OSINT.
 
 [OSINT Tools MCP Server](https://github.com/frishtik/osint-tools-mcp-server)
 
+[The Stall MCP](https://the-stall.intuitek.ai) — 173-tool remote MCP server with OSINT-relevant capabilities: IP intelligence, domain WHOIS, DNS lookup, OFAC sanctions screening, crypto wallet risk scoring, SEC insider trade filings, FEC political donor research, and congressional trading disclosures. No API key needed; x402 pay-per-call on Base.
+
 -----------
 
 ## Tools


### PR DESCRIPTION
## What

Adds **[The Stall MCP](https://the-stall.intuitek.ai)** to the MCP servers section.

## Why it fits

The Stall is a remote MCP server with several OSINT-relevant capabilities:

- **ip-intel** — IP geolocation, ASN, threat reputation, open ports
- **domain-whois** — WHOIS records, registrar, creation/expiry dates
- **dns-lookup** — A/AAAA/MX/TXT/NS/CNAME record resolution
- **sanctions-screening** — OFAC SDN Treasury database screening (19K+ entries, fuzzy name match)
- **wallet-screener** — crypto wallet risk score, sanctions flag, mixing exposure
- **sec-insider-trades** — SEC Form 4 filings (buys/sells/awards by name)
- **fec-donor-intel** — FEC political contribution records by person name
- **congressional-trades** — STOCK Act disclosure data for congressional trades
- **reddit-intel** — Reddit OSINT (user activity, post history, subreddit analysis)
- **social-intel** — Social footprint aggregation
- **legal-search** — Public legal record search

All tools are callable via MCP protocol (no API key required), with x402 USDC pay-per-call on Base for rate-limited endpoints (~$0.003–$0.008/call).

## Links
- MCP endpoint: `https://the-stall.intuitek.ai/mcp`
- Listed: Glama, official MCP registry, Smithery
